### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,6 @@
+# Change Log
+
+# 0.2.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+

--- a/actions/get_week_boundaries.yaml
+++ b/actions/get_week_boundaries.yaml
@@ -1,6 +1,6 @@
 ---
 name: get_week_boundaries
-runner_type: run-python
+runner_type: python-script
 description: Retrieve week boundary timestamps (week start and end) for the provided date.
 enabled: true
 entry_point: get_week_boundaries.py

--- a/actions/parse_date_string.yaml
+++ b/actions/parse_date_string.yaml
@@ -1,6 +1,6 @@
 ---
 name: parse_date_string
-runner_type: run-python
+runner_type: python-script
 description: Parse the (human readable) date string and return timestamp.
 enabled: true
 entry_point: parse_date_string.py

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ description: st2 content pack containing different date and time related functio
 keywords:
   - date
   - time
-version: 0.1.0
+version: 0.2.0
 author: StackStorm, Inc.
 email: info@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.