### PR TITLE
Updating for ST2 3.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # Change Log
 
+# 0.2.2
+
+- Updated date parser to use pypi managed package for `dateparser` (dateparser>=0.7.6)
+- Updated return for get_week_boundaries.py to be a properly formatted tuple
+
 # 0.2.0
 
 - Updated action `runner_type` from `run-python` to `python-script`
-

--- a/actions/get_week_boundaries.py
+++ b/actions/get_week_boundaries.py
@@ -16,4 +16,4 @@ class GetWeekBoundariesTimestampsAction(Action):
         start_timestamp = dt.floor('week').timestamp
         end_timestamp = dt.ceil('week').timestamp
 
-        return start_timestamp, end_timestamp
+        return (True, (start_timestamp, end_timestamp))

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ description: st2 content pack containing different date and time related functio
 keywords:
   - date
   - time
-version: 0.2.1
+version: 0.2.2
 python_versions:
   - "2"
   - "3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 arrow>=0.7.0,<0.8
--e git+https://github.com/Kami/dateparser.git@slots_fix#egg=dateparser
+dateparser>=0.7.6


### PR DESCRIPTION
- Updated date parser to use pypi managed package for `dateparser` (dateparser>=0.7.6)
- Updated return for get_week_boundaries.py to be a properly formatted tuple